### PR TITLE
Refactor factory seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,36 +86,35 @@ export default {
       instance: null,
       // created seeded data from Factories defined within your makeServer function,
       // with the key names corresponding to Factory names.
-      factorySeeds: {
+      factorySeeds: [
         // create 2 addresses with the same traits.
-        address: [{ traits: ['withRecipient', 'withCompleteAddress'], count: 2 }],
+        { factory: 'address', traits: ['withRecipient', 'withCompleteAddress'], count: 2 },
         // create a single cart item with no specific traits
-        cart: [{}],
+        { factory: 'cart' },
         // create 2 users that contain override values
-        user: [
-          {
-            traits: [
-              'withSomeTrait',
-              'withOtherTrait',
-              // override certain values
-              {
-                name: 'R2D2',
-                gender: 'Male',
-              },
-            ],
-          },
-          {
-            traits: [
-              'withSomeTrait',
-              'withOtherTrait',
-              {
-                name: 'BB8',
-                gender: 'Male',
-              },
-            ],
-          },
-        ],
-    },
+        {
+          factory: 'user',
+          traits: [
+            'withSomeTrait',
+            'withOtherTrait',
+            // override certain values
+            {
+              name: 'R2D2',
+              gender: 'Male',
+            },
+          ],
+        },
+        { factory: 'user',
+          traits: [
+            'withSomeTrait',
+            'withOtherTrait',
+            {
+              name: 'BB8',
+              gender: 'Male',
+            },
+          ],
+        },
+      ],
     }
   },
 };

--- a/src/withServer.js
+++ b/src/withServer.js
@@ -54,13 +54,10 @@ export const withServer = makeServer => (StoryFn) => {
       });
     }
     if (factorySeeds) {
-      Object.keys(factorySeeds).forEach(factoryName => {
-        const items = factorySeeds[factoryName];
-        items.forEach(item => {
-          const { traits = [], count = 1 } = item;
-          server.current.createList(factoryName, count, ...traits);
-        });
-      });
+      factorySeeds.forEach(item => {
+        const {factory, traits = [], count = 1} = item;
+        server.current.createList(factory, count, ...traits)
+      })
     }
 
     const {

--- a/stories/Users.js
+++ b/stories/Users.js
@@ -18,7 +18,7 @@ export const Users = () => {
     <article>
       <Header />
       <section>
-        <h3>Seeding data in a story</h3>
+        <h2>Seeding data in a story</h2>
         <div className="users-container">
           <p>
             This is an example list of users created via the factorySeeds
@@ -28,6 +28,7 @@ export const Users = () => {
             makeServer function
           </p>
           <ul>
+            {!Boolean(users.length) && "Loading..."}
             {users.map((user) => (
               <li key={user.id}>Name: {user.name}</li>
             ))}

--- a/stories/Users.stories.js
+++ b/stories/Users.stories.js
@@ -18,12 +18,10 @@ export const UserList = Template.bind({});
 
 UserList.parameters = {
   mirage: {
-    factorySeeds: {
-      user: [
-        { traits: [{ name: "John Doe" }] },
-        { traits: [{ name: "Luke Skywalker" }] },
-        { traits: [], count: 4 },
-      ],
-    },
+    factorySeeds: [
+      { factory: "user", traits: [{ name: "John Doe" }] },
+      { factory: "user", traits: [{ name: "Luke Skywalker" }] },
+      { factory: "user", traits: [], count: 4 },
+    ],
   },
 };


### PR DESCRIPTION
After reflecting on my approach today, I realized it might have not been the best way to structure the API. I think making the top level data type for `factorySeeds` an array makes it much easier to understand. And the factory name is now just a property included on the individual item objects.

Essentially what was originally this:
```
    factorySeeds: {
      user: [
        { traits: [{ name: "John Doe" }] },
        { traits: [{ name: "Luke Skywalker" }] },
        { traits: [], count: 4 },
      ],
      address: [
        { traits: ['withRecipient'] },
      ],
    },
```
now becomes:
```
    factorySeeds: [
      { factory: "user", traits: [{ name: "John Doe" }] },
      { factory: "user", traits: [{ name: "Luke Skywalker" }] },
      { factory: "user", traits: [], count: 4 },
      { factory: "address", traits: ['withRecipient] }
    ]
```

This makes it less silly to make an item with no traits which currently would be made by just adding an empty object as an item:
```
  factorySeeds: {
    user: [
      {}
    ]
  }
``` 
I think this is silly and was an oversight on my part. Instead this would become:

```
  factorySeeds: [
    { factory: 'user' }
  ]
```
I think this is more clear. If you agree, feel free to merge 😄 If you like the current way then that is also acceptable of course, and feel free to close this PR.
