### PR TITLE
feat: added ability to provide functions as parameter route handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ export default {
         get: {
           '/api/user': 404, // status code
           '/api/items': [204, {}, { items: [] }], // arguments for Response https://miragejs.com/api/classes/response/
+          '/api/items/:id': (schema, request) => // Route handler function https://miragejs.com/docs/main-concepts/route-handlers
+              new Response(200, {}, { id: request.params.id, name: `Item ${request.params.id}` })
         },
         post: {
           'api/task': { task: {} } // body for Response

--- a/src/withServer.js
+++ b/src/withServer.js
@@ -35,9 +35,10 @@ export const withServer = (makeServer) => (StoryFn) => {
       const set = handlers[method];
       Object.keys(set).forEach((route) => {
         const value = set[route];
-        globalThis.server[method](route, () => {
+        globalThis.server[method](route, (...args) => {
           if (typeof value === "number") return new Response(value);
           if (Array.isArray(value)) return new Response(...value);
+          if (typeof value === 'function') return value(...args);
           return new Response(200, {}, value);
         });
       });


### PR DESCRIPTION
There are times when it would be useful to have a custom function for a route handler only configured on a single story. Currently, the only way to provide a function for route handling is in the "makeServer" function that is generally created to initialize a server. This PR adds the ability to also provide function route handlers via the `parameters`.

Example Potential Usage:

```javascript
export default {
  // ...
  parameters: {
    mirage: {
      // ...
      handlers: {
        get: {
          '/api/user/:id': (schema, req) => {
            const idAsNum = Number(req.params.id);

            return (
              (!Number.isNaN(idAsNum) && idAsNum >= 400)
                ? new Response(idAsNum, {}, null)
                : new Response(200, {}, {
                  id: req.params.id,
                  name: faker.person.fullName()
                }
            );
          }
        }
      }
    }
  }
}
```