### PR TITLE
Upgrade nanoid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^4.0.0"
+        "nanoid": "^5.1.5"
       },
       "devDependencies": {
         "@auto-it/conventional-commits": "^11.1.6",
@@ -13893,14 +13893,21 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
-      "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/negotiator": {
@@ -28661,9 +28668,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
-      "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg=="
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw=="
     },
     "negotiator": {
       "version": "0.6.3",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,6 @@
     ]
   },
   "dependencies": {
-    "nanoid": "^4.0.0"
+    "nanoid": "^5.1.5"
   }
 }


### PR DESCRIPTION
Hi @HipsterBrown! I'm looking to upgrade nanoid to patch this security vulnerability: https://github.com/advisories/GHSA-mwcw-c2x4-8c55   

Nanoid v5 is the same as v4, except they dropped support for some older node versions.